### PR TITLE
Handle intro,elim,dest as Global Attributes

### DIFF
--- a/linter_base/src/lints.scala
+++ b/linter_base/src/lints.scala
@@ -472,9 +472,10 @@ object Global_Attribute_On_Unnamed_Lemma extends Parser_Lint
 
   val name: String = "global_attribute_on_unnamed_lemma"
   val severity: Severity.Level = Severity.Error
+  val GLOBAL_ATTRIBUTES = List("simp", "cong", "intro", "elim", "dest")
 
   private def simp_or_cong(attr: List[Elem]): Boolean = attr match {
-    case head :: _ => List("simp", "cong").contains(head.info.content)
+    case head :: _ => GLOBAL_ATTRIBUTES.contains(head.info.content)
     case _ => false
   }
 

--- a/linter_base/src/parsers.scala
+++ b/linter_base/src/parsers.scala
@@ -238,7 +238,7 @@ trait TokenParsers extends Parsers
     }
 
   /* Attributes */
-  def pAttribute: Parser[List[Elem]] = pIdent.*
+  def pAttribute: Parser[List[Elem]] = (pIdent | pKeyword("!") | pKeyword("?")).*
 
   def pAttributes: Parser[List[List[Elem]]] =
     chainl1[List[List[Elem]]](pAttribute ^^ {


### PR DESCRIPTION
"Global Attribute on Unnamed Lemma" wasn't considering the attributes
intro, elim and dest. Since these can be modified with "?" or "!", the
attribute parser also needed to be tweaked, since it previously only
parsed identifiers (e.g. simp or cong), which didn't cover "?!" because
they're keywords.

Closes #6 